### PR TITLE
Backend: working streaming implementation, very basic streaming (auto restarts)

### DIFF
--- a/backend/server/oceanhub/scripts/kafka_example.py
+++ b/backend/server/oceanhub/scripts/kafka_example.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+import threading, logging, time
+import multiprocessing
+
+from kafka import KafkaConsumer, KafkaProducer
+
+
+class Producer(threading.Thread):
+    def __init__(self):
+        threading.Thread.__init__(self)
+        self.stop_event = threading.Event()
+
+    def stop(self):
+        self.stop_event.set()
+
+    def run(self):
+        producer = KafkaProducer(bootstrap_servers='kafka:9092')
+
+        while not self.stop_event.is_set():
+            producer.send('video-stream', b"test")
+            producer.send('video-stream', b"\xc2Hola, mundo!")
+            time.sleep(1)
+
+        producer.close()
+
+class Consumer(multiprocessing.Process):
+    def __init__(self):
+        multiprocessing.Process.__init__(self)
+        self.stop_event = multiprocessing.Event()
+
+    def stop(self):
+        self.stop_event.set()
+
+    def run(self):
+        consumer = KafkaConsumer(bootstrap_servers='kafka:9092',
+                                 auto_offset_reset='earliest',
+                                 consumer_timeout_ms=1000)
+        consumer.subscribe(['video-stream'])
+
+        while not self.stop_event.is_set():
+            for message in consumer:
+                print(message)
+                if self.stop_event.is_set():
+                    break
+
+        consumer.close()
+
+
+def main():
+    tasks = [
+        Producer(),
+        Consumer()
+    ]
+
+    for t in tasks:
+        t.start()
+
+    time.sleep(10)
+
+    for task in tasks:
+        task.stop()
+
+    for task in tasks:
+        task.join()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        format='%(asctime)s.%(msecs)s:%(name)s:%(thread)d:%(levelname)s:%(process)d:%(message)s',
+        level=logging.INFO
+        )
+    main()

--- a/backend/server/oceanhub/scripts/producer.py
+++ b/backend/server/oceanhub/scripts/producer.py
@@ -1,18 +1,18 @@
 import time
 import cv2
-from kafka import SimpleProducer, KafkaClient
-#  connect to Kafka
-kafka = KafkaClient('localhost:9092')
-producer = SimpleProducer(kafka)
-# Assign a topic
-topic = 'my-topic'
+from kafka import KafkaProducer
 
 def video_emitter(video):
     # Open the video
     video = cv2.VideoCapture(video)
     print(' emitting.....')
+    #  connect to Kafka
+    producer = KafkaProducer(bootstrap_servers='kafka:9092')
+    # Assign a topic
+    topic = 'video-stream'
 
     # read the file
+    i = 0
     while (video.isOpened):
         # read the image in each frame
         success, image = video.read()
@@ -22,12 +22,15 @@ def video_emitter(video):
         # convert the image png
         ret, jpeg = cv2.imencode('.png', image)
         # Convert the image to bytes and send to kafka
-        producer.send_messages(topic, jpeg.tobytes())
+        producer.send(topic, jpeg.tobytes())
+        i += 1
+        print('Frame No. %s' % i)
         # To reduce CPU usage create sleep time of 0.2sec
         time.sleep(0.2)
-    # clear the capture
+        # clear the capture
     video.release()
+    producer.close()
     print('done emitting')
 
-if __name__ == '__main__':
-    video_emitter('video.mp4')
+def test_video():
+    video_emitter('SampleVideo_1280x720_5mb.mp4')

--- a/backend/server/oceanhub/scripts/shell.py
+++ b/backend/server/oceanhub/scripts/shell.py
@@ -1,8 +1,11 @@
+from oceanhub.scripts.producer import test_video
+
 def test_global():
     print('Hi, my name is Si!')
 
 
 def make_shell_context():  # get all the tasks loaded up into the application
     return {
-        'test_global': test_global
+        'test_global': test_global,
+        'test_producer_video': test_video
     }

--- a/backend/server/oceanhub/videos/views.py
+++ b/backend/server/oceanhub/videos/views.py
@@ -1,8 +1,22 @@
-from flask import Blueprint
+from flask import Blueprint, Response
+from kafka import KafkaConsumer
 
 videos_blueprint = Blueprint('videos', __name__)
+#Continuously listen to the connection and print messages as recieved
 
 @videos_blueprint.route('/')
 def index():
-    # return a multipart response
-    return 'Hello World'
+    consumer = KafkaConsumer(bootstrap_servers='kafka:9092',
+                            auto_offset_reset='earliest',
+                            consumer_timeout_ms=1000)
+    consumer.subscribe(['video-stream'])
+    return Response(kafkastream(consumer),
+                        mimetype='multipart/x-mixed-replace; boundary=frame')
+
+def kafkastream(consumer):
+    for msg in consumer:
+        # print(msg.value)
+        # print(msg.offset)
+        yield (b'--frame\r\n'
+               b'Content-Type: image/png\r\n\r\n' + msg.value + b'\r\n\r\n')
+

--- a/infra/docker_dev/Dockerfile_server
+++ b/infra/docker_dev/Dockerfile_server
@@ -10,13 +10,14 @@ RUN apt-get update -yqq \
     software-properties-common
 
 # -- Install Python dependencies
-RUN apt-get install -yqq --no-install-recommends \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -yqq --no-install-recommends \
     build-essential \
     python3.7 \
     python3.7-dev \
     python3-pip \
     git \
     wget \
+    python3-opencv \
   && apt-get -q clean
 
 # -- Install Application into container:

--- a/infra/docker_dev/docker-compose.yml
+++ b/infra/docker_dev/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 
 services:
   oceanhub_server:
+    restart: always
     build:
       context: ../../
       dockerfile: ./infra/docker_dev/Dockerfile_server
@@ -19,16 +20,17 @@ services:
   kafka:
     image: wurstmeister/kafka:0.10.1.0
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: 0.0.0.0
+      KAFKA_ADVERTISED_HOST_NAME: kafka
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_CREATE_TOPICS: "messages:1:1"
+      KAFKA_CREATE_TOPICS: "video-stream:1:1"
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
     ports:
       - 9092:9092
     expose:
       - 9092
+    hostname: kafka
     volumes:
-      - kafkavolume:/var/run/docker.sock
-volumes:
-  kafkavolume:
+      - /var/run/docker.sock:/var/run/docker.sock
+    links:
+      - zookeeper


### PR DESCRIPTION
## Overview

working streaming implementation, very basic streaming (auto restarts)

### Notes

* Note that for some reason OpenCV recognizes a small chunk of the video. Need to figure it out exactly why.

* All of the videos are stored as raw bytes in Kafka. OpenCV can easily serialize + deserialize the components easily.

* We need to somehow divide the requests into multiple parts (like how youtube does it). Not just streaming at once. We should also implement expiration to avoid hogging the browser.



## Testing Instructions
* Please rebuild your images
* Send the video to the producer 
-> `docker-compose -f infra/docker_dev/docker-compose.yml run oceanhub_server bash -c "source activate TEST && python backend/server/manage.py shell"`
-> test_producer_video()
* Go to http://localhost:5000/videos/ to see it subscribing to the producer (in this case, the /videos/  endpoint acts as a consumer)

