### PR TITLE
Configure different param settings to display the whole video

### DIFF
--- a/backend/server/oceanhub/scripts/producer.py
+++ b/backend/server/oceanhub/scripts/producer.py
@@ -19,11 +19,16 @@ def video_emitter(video):
         # check if the file has read to the end
         if not success:
             break
-        # convert the image png
-        ret, jpeg = cv2.imencode('.png', image)
+        # convert the image jpg, lower quality for now (we don't need to bloat the browser)
+        encoding_param = [int(cv2.IMWRITE_JPEG_QUALITY), 70]
+        ret, jpeg = cv2.imencode('.jpg', image, encoding_param)
+
         # Convert the image to bytes and send to kafka
-        producer.send(topic, jpeg.tobytes())
+        byte = jpeg.tobytes()
+        producer.send(topic, byte)
         i += 1
+
+        print('bytesize %s', len(byte))
         print('Frame No. %s' % i)
         # To reduce CPU usage create sleep time of 0.2sec
         time.sleep(0.2)

--- a/backend/server/oceanhub/videos/views.py
+++ b/backend/server/oceanhub/videos/views.py
@@ -18,5 +18,5 @@ def kafkastream(consumer):
         # print(msg.value)
         # print(msg.offset)
         yield (b'--frame\r\n'
-               b'Content-Type: image/png\r\n\r\n' + msg.value + b'\r\n\r\n')
+               b'Content-Type: image/jpeg\r\n\r\n' + msg.value + b'\r\n\r\n')
 

--- a/infra/docker_dev/docker-compose.yml
+++ b/infra/docker_dev/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
       KAFKA_CREATE_TOPICS: "video-stream:1:1"
       KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+      KAFKA_MESSAGE_MAX_BYTES: 2000000
+      # IDK what the flag for fetch.message.max.bytes is on here
+      # (might need to copy the configfile over to the Kafka container)
     ports:
       - 9092:9092
     expose:


### PR DESCRIPTION
## Overview

Configure different param settings to display the whole video.

### Notes

* Ideally, we want to fine tune the videos displayed to the frontend. We should specify video qualities like they do in YouTube so that we can control our resources in a much more granular way.

* Needs to figure out how to properly stream + buffer for more, because we don't want to load a 10 GB video all at once. Make use of Kafka's consumer API and partitioning.

* @dwinasolihin @scaraclette heads up, hopefully you can play around with this API a bit more to get a sense what to do with the API.

* @lsetiawan We can build out a proxy endpoint to show the video list (attained from the website you showed us) to the frontend. And, also finetune the streaming endpoint for the video. We can parallelize the work.

* @scaraclette like I said yesterday, if you are interested in building a service in Python (to get some experience) to parse the information from the website @lsetiawan  showed us, let me know :)

## Testing Instructions

* Please rebuild your images
* Send the video to the producer
-> docker-compose -f infra/docker_dev/docker-compose.yml run oceanhub_server bash -c "source activate TEST && python backend/server/manage.py shell"
-> test_producer_video()
* Go to http://localhost:5000/videos/ to see it subscribing to the producer (in this case, the /videos/ endpoint acts as a consumer)