### PR TITLE
k8s service configs for Kafka, docker-compose updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ From the root folder of the project:
 # Note, these are not sequential steps. You can use any of them independently of each other.
 
 # To run bash shell
-docker-compose -f infra/docker_dev/docker-compose.yml run --rm oceanhub_server bash
+docker-compose -f infra/docker_dev/docker-compose.yml run --rm oceanhub-server bash
 
 # To run Flask Python shell
-docker-compose -f infra/docker_dev/docker-compose.yml run --rm oceanhub_server bash -c "source activate TEST && python backend/server/manage.py shell"
+docker-compose -f infra/docker_dev/docker-compose.yml run --rm oceanhub-server bash -c "source activate TEST && python backend/server/manage.py shell"
 
 # To run the cluster up
 docker-compose -f infra/docker_dev/docker-compose.yml up

--- a/infra/docker_dev/docker-compose.yml
+++ b/infra/docker_dev/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 
 services:
-  oceanhub_server:
+  oceanhub-server:
     build:
       context: ../../
       dockerfile: ./infra/docker_dev/Dockerfile_server
@@ -10,13 +10,13 @@ services:
     ports:
       - 5000:5000
     links:
-      - kafka
+      - kafka-cluster
     command: bash -c "source activate TEST && python backend/server/manage.py runserver"
   zookeeper:
     image: wurstmeister/zookeeper
     ports:
       - 2181:2181
-  kafka:
+  kafka-cluster:
     image: wurstmeister/kafka:0.10.1.0
     environment:
       KAFKA_ADVERTISED_HOST_NAME: kafka

--- a/infra/k8s_prod/kafka-cluster-claim0-persistentvolumeclaim.yaml
+++ b/infra/k8s_prod/kafka-cluster-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  creationTimestamp: null
+  labels:
+    io.kompose.service: kafka-cluster-claim0
+  name: kafka-cluster-claim0
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}

--- a/infra/k8s_prod/kafka-cluster-deployment.yaml
+++ b/infra/k8s_prod/kafka-cluster-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yml
+    kompose.version: 1.16.0 (0c01309)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: kafka-cluster
+  name: kafka-cluster
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: kafka-cluster
+    spec:
+      containers:
+      - env:
+        - name: KAFKA_ADVERTISED_HOST_NAME
+          value: kafka
+        - name: KAFKA_ADVERTISED_PORT
+          value: "9092"
+        - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+          value: "true"
+        - name: KAFKA_CREATE_TOPICS
+          value: video-stream:1:1
+        - name: KAFKA_MESSAGE_MAX_BYTES
+          value: "2000000"
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: zookeeper:2181
+        image: wurstmeister/kafka:0.10.1.0
+        name: kafka-cluster
+        ports:
+        - containerPort: 9092
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: kafka-cluster-claim0
+      hostname: kafka
+      restartPolicy: Always
+      volumes:
+      - name: kafka-cluster-claim0
+        persistentVolumeClaim:
+          claimName: kafka-cluster-claim0
+status: {}

--- a/infra/k8s_prod/kafka-cluster-service.yaml
+++ b/infra/k8s_prod/kafka-cluster-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yml
+    kompose.version: 1.16.0 (0c01309)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: kafka-cluster
+  name: kafka-cluster
+spec:
+  ports:
+  - name: "9092"
+    port: 9092
+    targetPort: 9092
+  selector:
+    io.kompose.service: kafka-cluster
+status:
+  loadBalancer: {}

--- a/infra/k8s_prod/zookeeper-deployment.yaml
+++ b/infra/k8s_prod/zookeeper-deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yml
+    kompose.version: 1.16.0 (0c01309)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: zookeeper
+  name: zookeeper
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: zookeeper
+    spec:
+      containers:
+      - image: wurstmeister/zookeeper
+        name: zookeeper
+        ports:
+        - containerPort: 2181
+        resources: {}
+      restartPolicy: Always
+status: {}

--- a/infra/k8s_prod/zookeeper-service.yaml
+++ b/infra/k8s_prod/zookeeper-service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose convert -f docker-compose.yml
+    kompose.version: 1.16.0 (0c01309)
+  creationTimestamp: null
+  labels:
+    io.kompose.service: zookeeper
+  name: zookeeper
+spec:
+  ports:
+  - name: "2181"
+    port: 2181
+    targetPort: 2181
+  selector:
+    io.kompose.service: zookeeper
+status:
+  loadBalancer: {}


### PR DESCRIPTION
## Overview

This is a simple Kubernetes simple Kafka + Zookeeper service config. This is tested locally, but the underlying production cluster needs to be tested on the cloud. I am planning to utilize Google Cloud's free services for now.

### Demo

```
22:29 $ kubectl describe services
Name:              kafka-cluster
Namespace:         default
Labels:            io.kompose.service=kafka-cluster
Annotations:       kompose.cmd=kompose convert -f docker-compose.yml
                   kompose.version=1.16.0 (0c01309)
Selector:          io.kompose.service=kafka-cluster
Type:              ClusterIP
IP:                10.109.138.87
Port:              9092  9092/TCP
TargetPort:        9092/TCP
Endpoints:         10.1.0.15:9092
Session Affinity:  None
Events:            <none>


Name:              kubernetes
Namespace:         default
Labels:            component=apiserver
                   provider=kubernetes
Annotations:       <none>
Selector:          <none>
Type:              ClusterIP
IP:                10.96.0.1
Port:              https  443/TCP
TargetPort:        6443/TCP
Endpoints:         192.168.65.3:6443
Session Affinity:  ClientIP
Events:            <none>


Name:              zookeeper
Namespace:         default
Labels:            io.kompose.service=zookeeper
Annotations:       kompose.cmd=kompose convert -f docker-compose.yml
                   kompose.version=1.16.0 (0c01309)
Selector:          io.kompose.service=zookeeper
Type:              ClusterIP
IP:                10.99.68.36
Port:              2181  2181/TCP
TargetPort:        2181/TCP
Endpoints:         10.1.0.16:2181
Session Affinity:  None
Events:            <none>
```

## Testing Instructions

* Install Kubernetes locally
* `cd infra/k8s_prod && kubectl create -f kafka-cluster-claim0-persistentvolumeclaim.yaml,kafka-cluster-deployment.yaml,kafka-cluster-service.yaml,zookeeper-deployment.yaml,zookeeper-service.yaml`

## Notes
* There must be a more granular way of deploying the services from inside a directory. Either way, we need these config files for creating the infrastructure anyway. [Google's Kubernetes Engine](https://cloud.google.com/kubernetes-engine/docs/) and [Terraform](https://blog.gruntwork.io/an-introduction-to-terraform-f17df9c6d180?gi=beb7e199e3f4) should make it really easy to set k8s in there.

* If anybody wants any insight as to what this does under the hood, hit me up fam!
